### PR TITLE
Fix error when starting

### DIFF
--- a/willie/bot.py
+++ b/willie/bot.py
@@ -31,12 +31,7 @@ class Willie(irc.Bot):
 
     def __init__(self, config):
         irc.Bot.__init__(self, config.core)
-        self.config.lang = "en" # Travis CI stuff
-        try:
-            self.config = config
-            self.config.lang = config.lang # :P
-        except:
-            pass
+        self.config = config
         """The ``Config`` for the current Willie instance."""
         self.doc = {}
         """


### PR DESCRIPTION
Traceback (most recent call last):
  File "C:\Users\JeDaYoshi\Granota\willie__init__.py", line 37, in run
    p = bot.Willie(config)
  File "C:\Users\JeDaYoshi\Granota\willie\bot.py", line 34, in **init**
    self.config.lang = "en" # Travis CI stuff
  File "C:\Python27\lib\asyncore.py", line 421, in **getattr**
    %(self.**class**.**name**, attr))
AttributeError: Willie instance has no attribute 'config'

Now it's fixed.
